### PR TITLE
Change HTTP `HandlerError` universal from derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error-derive"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error-http"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix-web",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix-web",
  "explicit-error-exit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error-derive"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/explicit-error-derive/Cargo.toml
+++ b/explicit-error-derive/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error-derive"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.1.3"
+version = "0.1.4"
 
 [lib]
 proc-macro = true

--- a/explicit-error-derive/Cargo.toml
+++ b/explicit-error-derive/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error-derive"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.1.4"
+version = "0.1.5"
 
 [lib]
 proc-macro = true

--- a/explicit-error-derive/src/actix.rs
+++ b/explicit-error-derive/src/actix.rs
@@ -26,7 +26,7 @@ pub fn derive(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
                 match self.error() {
                     explicit_error_http::Error::Domain(d) => {
                         let status_code = d.output.http_status_code;
-                        HttpResponse::build(status_code).json(<Self as HandlerError>::domain_response(d))
+                        actix_web::HttpResponse::build(status_code).json(<Self as HandlerError>::domain_response(d))
                     },
                     explicit_error_http::Error::Bug(b) => actix_web::HttpResponse::InternalServerError().json(<Self as explicit_error_http::HandlerError>::public_bug_response(b)),
                 }

--- a/explicit-error-derive/src/actix.rs
+++ b/explicit-error-derive/src/actix.rs
@@ -6,18 +6,6 @@ pub fn derive(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
 
     let mut from_impl_generics = input.generics.clone();
     from_impl_generics.params.push(syn::parse_str("EE")?);
-    let explicit_error_http_where = "EE: Into<explicit_error_http::Error>";
-    let from_where_clause = where_clause.map_or(
-        syn::parse_str(&format!("where {explicit_error_http_where}"))?,
-        |w| {
-            let mut c = w.clone();
-
-            c.predicates
-                .push(syn::parse_str(explicit_error_http_where).unwrap());
-
-            c
-        },
-    );
 
     Ok(quote! {
         #[automatically_derived]
@@ -34,9 +22,22 @@ pub fn derive(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         }
 
         #[automatically_derived]
-        impl #from_impl_generics From<EE> for #ident #ty_generics #from_where_clause
-        {
-            fn from(value: EE) -> Self {
+        impl #impl_generics From<explicit_error_http::Bug> for #ident #ty_generics #where_clause {
+            fn from(value: explicit_error_http::Bug) -> Self {
+                <Self as explicit_error_http::HandlerError>::from_error(value.into())
+            }
+        }
+
+        #[automatically_derived]
+        impl #impl_generics From<explicit_error_http::Error> for #ident #ty_generics #where_clause {
+            fn from(value: explicit_error_http::Error) -> Self {
+                <Self as explicit_error_http::HandlerError>::from_error(value)
+            }
+        }
+
+        #[automatically_derived]
+        impl #impl_generics From<explicit_error_http::HttpError> for #ident #ty_generics #where_clause {
+            fn from(value: explicit_error_http::HttpError) -> Self {
                 <Self as explicit_error_http::HandlerError>::from_error(value.into())
             }
         }

--- a/explicit-error-http/Cargo.toml
+++ b/explicit-error-http/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error-http"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.1.3"
+version = "0.1.4"
 
 [features]
 actix-web = ["dep:actix-web", "explicit-error-derive/actix-web"]

--- a/explicit-error-http/examples/actix.rs
+++ b/explicit-error-http/examples/actix.rs
@@ -1,6 +1,6 @@
-use actix_web::{App, HttpResponse, HttpServer, get};
+use actix_web::{App, HttpResponse, HttpServer, get, http::StatusCode};
 use env_logger::Env;
-use explicit_error_http::{Bug, Error, HandlerError, derive::HandlerErrorHelpers};
+use explicit_error_http::{Bug, Error, HandlerError, HttpError, derive::HandlerErrorHelpers};
 use log::{debug, error};
 use problem_details::ProblemDetails;
 use serde::Serialize;
@@ -50,6 +50,12 @@ async fn domain_error() -> Result<HttpResponse, MyHandlerError> {
 #[get("/bug")]
 async fn bug_error() -> Result<HttpResponse, MyHandlerError> {
     service::fetch_entity()?;
+
+    Err(HttpError {
+        http_status_code: StatusCode::FORBIDDEN,
+        public: Box::new(""),
+        context: None,
+    })?;
 
     Ok(HttpResponse::Ok().finish())
 }

--- a/explicit-error-http/src/error.rs
+++ b/explicit-error-http/src/error.rs
@@ -171,6 +171,7 @@ pub(crate) struct HttpErrorDisplay<'s> {
 impl<'s> From<&'s HttpError> for HttpErrorDisplay<'s> {
     fn from(value: &'s HttpError) -> Self {
         Self {
+            #[cfg(feature = "actix-web")]
             http_status_code: value.http_status_code,
             public: value.public.as_ref(),
             context: value.context.as_deref(),

--- a/explicit-error/Cargo.toml
+++ b/explicit-error/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.1.3"
+version = "0.1.4"
 
 [dependencies]
 serde = {version = "1.0.219", features = ["derive"]}


### PR DESCRIPTION
Originally any type deriving `HandlerErrorHelpers` had the following convert: `From<E> for #ident where E: Into<explicit_error_http::Error>`.

This was great because any type that derive either `HttpError` or `ExitError` (`Bug` and `Error` also) automatically converted to types deriving `HandlerErrorHelpers`. But it prevents any `From` implementation on them because of the compiler `upstream crates may add a new impl of trait`. This was especially annoying for recurrent handlers errors from external crates (eg: authorization). Moreover From implementation for error handling is really idiomatic in Rust, loosing this ability must have a strong reason. 

Because the trade off is bad, it is not worth it. The `From<E> for #ident where E: Into<explicit_error_http::Error>` was replaced by concrete types `From` implementation for: `Bug`, `Error` and `HttpError`.