### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - uses: extractions/setup-just@v3
     - name: Cache
       uses: actions/cache@v4
       with:
@@ -33,9 +34,7 @@ jobs:
     - name: Format
       run: cargo fmt --check
     - name: Run tests
-      run: |
-        cargo test --verbose
-        cargo build --example actix
+      run: just test
     - name: Doc
       run: cargo doc
     - name: Publish dry run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Run tests
       run: just test
     - name: Doc
-      run: cargo doc
+      run: cargo doc --all-features
     - name: Publish dry run
       run: |
         cargo publish -p explicit-error --dry-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "actix-web",
  "explicit-error-exit",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error-derive"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error-exit"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "explicit-error",
  "explicit-error-derive",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error-http"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "actix-web",
  "env_logger",

--- a/explicit-error-derive/Cargo.toml
+++ b/explicit-error-derive/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error-derive"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.1.6"
+version = "0.1.7"
 
 [lib]
 proc-macro = true

--- a/explicit-error-derive/src/actix.rs
+++ b/explicit-error-derive/src/actix.rs
@@ -8,10 +8,10 @@ pub fn derive(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         #[automatically_derived]
         impl #impl_generics actix_web::ResponseError for #ident #ty_generics #where_clause {
             fn error_response(&self) -> actix_web::HttpResponse {
-                match self.error() {
+                match <Self as explicit_error_http::HandlerError>::error(self) {
                     explicit_error_http::Error::Domain(d) => {
                         let status_code = d.output.http_status_code;
-                        actix_web::HttpResponse::build(status_code).json(<Self as HandlerError>::domain_response(d))
+                        actix_web::HttpResponse::build(status_code).json(<Self as explicit_error_http::HandlerError>::domain_response(d))
                     },
                     explicit_error_http::Error::Fault(b) => actix_web::HttpResponse::InternalServerError().json(<Self as explicit_error_http::HandlerError>::public_fault_response(b)),
                 }
@@ -42,14 +42,14 @@ pub fn derive(input: syn::DeriveInput) -> syn::Result<proc_macro2::TokenStream> 
         #[automatically_derived]
         impl #impl_generics std::fmt::Display for #ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                std::fmt::Display::fmt(self.error(), f)
+                std::fmt::Display::fmt(<Self as explicit_error_http::HandlerError>::error(self), f)
             }
         }
 
         #[automatically_derived]
         impl #impl_generics std::fmt::Debug for #ident #ty_generics #where_clause {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                std::fmt::Debug::fmt(self.error(), f)
+                std::fmt::Debug::fmt(<Self as explicit_error_http::HandlerError>::error(self), f)
             }
         }
     })

--- a/explicit-error-derive/src/lib.rs
+++ b/explicit-error-derive/src/lib.rs
@@ -5,7 +5,7 @@ extern crate syn;
 
 #[cfg(feature = "actix-web")]
 mod actix;
-#[cfg(any(feature = "exit", feature = "actix-web"))]
+#[cfg(any(feature = "exit", feature = "http"))]
 mod domain;
 
 #[cfg(any(feature = "http", feature = "exit", feature = "actix-web"))]

--- a/explicit-error-exit/Cargo.toml
+++ b/explicit-error-exit/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error-exit"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.1.3"
+version = "0.1.4"
 
 [dependencies]
 explicit-error = {version = "0", path = "../explicit-error"}

--- a/explicit-error-exit/src/domain.rs
+++ b/explicit-error-exit/src/domain.rs
@@ -115,6 +115,10 @@ impl Domain for DomainError {
         self.source
     }
 
+    fn context(&self) -> Option<&str> {
+        self.output.context.as_deref()
+    }
+
     fn with_context(mut self, context: impl Display) -> Self {
         self.output = self.output.with_context(context);
         self

--- a/explicit-error-http/Cargo.toml
+++ b/explicit-error-http/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error-http"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.1.5"
+version = "0.1.6"
 
 [features]
 actix-web = ["dep:actix-web", "explicit-error-derive/actix-web"]

--- a/explicit-error-http/Cargo.toml
+++ b/explicit-error-http/Cargo.toml
@@ -12,13 +12,12 @@ version = "0.1.5"
 
 [features]
 actix-web = ["dep:actix-web", "explicit-error-derive/actix-web"]
-default = ["actix-web"]
 
 [dependencies]
 actix-web = {version = "4.10.2", default-features = false, optional = true}
 erased-serde = "0.4.6"
 explicit-error = {version = "0", path = "../explicit-error"}
-explicit-error-derive = {version = "0", path = "../explicit-error-derive"}
+explicit-error-derive = {version = "0", path = "../explicit-error-derive", features = ["http"]}
 http = "1.3.1"
 problem_details = "0.8.0"
 serde = "1.0.219"

--- a/explicit-error-http/src/domain.rs
+++ b/explicit-error-http/src/domain.rs
@@ -105,6 +105,10 @@ impl Domain for DomainError {
         self.source
     }
 
+    fn context(&self) -> Option<&str> {
+        self.output.context.as_deref()
+    }
+
     fn with_context(mut self, context: impl std::fmt::Display) -> Self {
         self.output = self.output.with_context(context);
         self

--- a/explicit-error-http/src/domain/test.rs
+++ b/explicit-error-http/src/domain/test.rs
@@ -1,9 +1,159 @@
 use super::*;
+use actix_web::http::StatusCode;
 
 #[derive(Serialize)]
 struct ErrorBody {
     foo: &'static str,
     bar: i64,
+}
+
+#[test]
+fn into_source() {
+    assert!(
+        DomainError {
+            output: HttpError {
+                #[cfg(feature = "actix-web")]
+                http_status_code: StatusCode::BAD_REQUEST,
+                public: Box::new(""),
+                context: None,
+            },
+            source: None,
+        }
+        .into_source()
+        .is_none()
+    );
+
+    assert!(
+        DomainError {
+            output: HttpError {
+                #[cfg(feature = "actix-web")]
+                http_status_code: StatusCode::BAD_REQUEST,
+                public: Box::new(""),
+                context: None,
+            },
+            source: Some(Box::new(sqlx::Error::RowNotFound)),
+        }
+        .into_source()
+        .unwrap()
+        .downcast::<sqlx::Error>()
+        .is_ok()
+    );
+}
+
+#[test]
+fn with_context() {
+    let domain = DomainError {
+        output: HttpError {
+            #[cfg(feature = "actix-web")]
+            http_status_code: StatusCode::BAD_REQUEST,
+            public: Box::new(""),
+            context: None,
+        },
+        source: None,
+    }
+    .with_context("context");
+
+    assert_eq!(domain.output.context.as_ref().unwrap(), "context");
+    assert_eq!(
+        domain.with_context("context 2").output.context.unwrap(),
+        "context 2"
+    );
+}
+
+#[test]
+fn context() {
+    assert!(
+        DomainError {
+            output: HttpError {
+                #[cfg(feature = "actix-web")]
+                http_status_code: StatusCode::BAD_REQUEST,
+                public: Box::new(""),
+                context: None,
+            },
+            source: None,
+        }
+        .context()
+        .is_none(),
+    );
+
+    assert_eq!(
+        DomainError {
+            output: HttpError {
+                #[cfg(feature = "actix-web")]
+                http_status_code: StatusCode::BAD_REQUEST,
+                public: Box::new(""),
+                context: Some("context".to_string()),
+            },
+            source: None,
+        }
+        .context()
+        .unwrap(),
+        "context"
+    );
+}
+
+#[test]
+fn source() {
+    assert!(
+        DomainError {
+            output: HttpError {
+                #[cfg(feature = "actix-web")]
+                http_status_code: StatusCode::BAD_REQUEST,
+                public: Box::new(""),
+                context: None,
+            },
+            source: None,
+        }
+        .source()
+        .is_none()
+    );
+
+    assert!(
+        DomainError {
+            output: HttpError {
+                #[cfg(feature = "actix-web")]
+                http_status_code: StatusCode::BAD_REQUEST,
+                public: Box::new(""),
+                context: None,
+            },
+            source: Some(Box::new(sqlx::Error::RowNotFound)),
+        }
+        .source()
+        .unwrap()
+        .downcast_ref::<sqlx::Error>()
+        .is_some()
+    );
+}
+
+#[test]
+fn from_domain_for_error() {
+    let domain = Error::from(DomainError {
+        output: HttpError {
+            #[cfg(feature = "actix-web")]
+            http_status_code: StatusCode::BAD_REQUEST,
+            public: Box::new(ErrorBody {
+                foo: "foo",
+                bar: 42,
+            }),
+            context: None,
+        },
+        source: None,
+    })
+    .unwrap();
+
+    assert_eq!(
+        domain.output,
+        HttpError {
+            #[cfg(feature = "actix-web")]
+            http_status_code: StatusCode::BAD_REQUEST,
+            public: Box::new(ErrorBody {
+                foo: "foo",
+                bar: 42,
+            }),
+            context: None,
+        }
+    );
+    assert!(domain.source.is_none());
 }
 
 #[test]
@@ -46,5 +196,102 @@ fn display() {
         ),
         r#"{"context":"context","http_status_code":400,"public":{"bar":42,"foo":"foo"},"source":"PoolClosed"}"#
             .to_string()
+    );
+}
+
+#[derive(Debug)]
+struct MyDomainError;
+
+impl From<&MyDomainError> for HttpError {
+    fn from(_: &MyDomainError) -> Self {
+        HttpError {
+            #[cfg(feature = "actix-web")]
+            http_status_code: actix_web::http::StatusCode::BAD_REQUEST,
+            public: Box::new(ErrorBody {
+                foo: "foo",
+                bar: 42,
+            }),
+            context: Some("context".to_string()),
+        }
+    }
+}
+
+impl StdError for MyDomainError {}
+
+impl std::fmt::Display for MyDomainError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Self as ToDomainError>::display(self, f)
+    }
+}
+
+impl From<MyDomainError> for crate::Error {
+    fn from(value: MyDomainError) -> Self {
+        Error::from(value.to_domain_error())
+    }
+}
+
+impl ToDomainError for MyDomainError {}
+
+#[test]
+fn to_domain_error() {
+    let domain_error = MyDomainError.to_domain_error();
+
+    assert_eq!(
+        domain_error.output,
+        HttpError {
+            #[cfg(feature = "actix-web")]
+            http_status_code: actix_web::http::StatusCode::BAD_REQUEST,
+            public: Box::new(ErrorBody {
+                foo: "foo",
+                bar: 42,
+            }),
+            context: Some("context".to_string()),
+        }
+    );
+    assert!(
+        domain_error
+            .source
+            .as_ref()
+            .unwrap()
+            .downcast_ref::<MyDomainError>()
+            .is_some()
+    );
+
+    assert_eq!(
+        domain_error.to_string(),
+        r#"{"context":"context","http_status_code":400,"public":{"bar":42,"foo":"foo"},"source":"MyDomainError"}"#
+    );
+}
+
+#[test]
+fn result_domain_with_context() {
+    let domain_error = Err::<(), _>(MyDomainError)
+        .with_context("context 2")
+        .unwrap_err();
+
+    assert_eq!(
+        domain_error.output,
+        HttpError {
+            #[cfg(feature = "actix-web")]
+            http_status_code: actix_web::http::StatusCode::BAD_REQUEST,
+            public: Box::new(ErrorBody {
+                foo: "foo",
+                bar: 42,
+            }),
+            context: Some("context 2".to_string()),
+        }
+    );
+    assert!(
+        domain_error
+            .source
+            .as_ref()
+            .unwrap()
+            .downcast_ref::<MyDomainError>()
+            .is_some()
+    );
+
+    assert_eq!(
+        domain_error.to_string(),
+        r#"{"context":"context 2","http_status_code":400,"public":{"bar":42,"foo":"foo"},"source":"MyDomainError"}"#
     );
 }

--- a/explicit-error-http/src/error.rs
+++ b/explicit-error-http/src/error.rs
@@ -159,6 +159,23 @@ impl From<HttpError> for Error {
     }
 }
 
+#[cfg(feature = "actix-web")]
+impl PartialEq for HttpError {
+    fn eq(&self, other: &Self) -> bool {
+        self.context == other.context
+            && self.http_status_code == other.http_status_code
+            && serde_json::json!(self.public).to_string() == serde_json::json!(other).to_string()
+    }
+}
+
+#[cfg(not(feature = "actix-web"))]
+impl PartialEq for HttpError {
+    fn eq(&self, other: &Self) -> bool {
+        self.context == other.context
+            && serde_json::json!(self.public).to_string() == serde_json::json!(other).to_string()
+    }
+}
+
 #[derive(Serialize)]
 pub(crate) struct HttpErrorDisplay<'s> {
     #[cfg(feature = "actix-web")]

--- a/explicit-error-http/src/error.rs
+++ b/explicit-error-http/src/error.rs
@@ -164,15 +164,14 @@ impl PartialEq for HttpError {
     fn eq(&self, other: &Self) -> bool {
         self.context == other.context
             && self.http_status_code == other.http_status_code
-            && serde_json::json!(self.public).to_string() == serde_json::json!(other).to_string()
+            && serde_json::json!(self.public) == serde_json::json!(other)
     }
 }
 
 #[cfg(not(feature = "actix-web"))]
 impl PartialEq for HttpError {
     fn eq(&self, other: &Self) -> bool {
-        self.context == other.context
-            && serde_json::json!(self.public).to_string() == serde_json::json!(other).to_string()
+        self.context == other.context && serde_json::json!(self.public) == serde_json::json!(other)
     }
 }
 

--- a/explicit-error-http/src/error/test.rs
+++ b/explicit-error-http/src/error/test.rs
@@ -46,7 +46,7 @@ fn with_context() {
 
 #[test]
 fn from_http_error_for_error() {
-    let error = crate::Error::from(HttpError {
+    let domain_error = crate::Error::from(HttpError {
         #[cfg(feature = "actix-web")]
         http_status_code: StatusCode::BAD_REQUEST,
         public: Box::new(ErrorBody {
@@ -56,14 +56,19 @@ fn from_http_error_for_error() {
         context: None,
     })
     .unwrap();
-
-    assert_eq!(error.output.context, None);
-    #[cfg(feature = "actix-web")]
-    assert_eq!(error.output.http_status_code, StatusCode::BAD_REQUEST);
     assert_eq!(
-        serde_json::json!(error.output).to_string(),
-        r#"{"bar":42,"foo":"foo"}"#
+        HttpError {
+            #[cfg(feature = "actix-web")]
+            http_status_code: StatusCode::BAD_REQUEST,
+            public: Box::new(ErrorBody {
+                foo: "foo",
+                bar: 42,
+            }),
+            context: None,
+        },
+        domain_error.output
     );
+    assert!(domain_error.source.is_none());
 }
 
 #[test]

--- a/explicit-error-http/src/error/test.rs
+++ b/explicit-error-http/src/error/test.rs
@@ -1,4 +1,5 @@
 use super::*;
+#[cfg(feature = "actix-web")]
 use actix_web::http::StatusCode;
 
 #[derive(Serialize)]
@@ -90,20 +91,27 @@ fn serialize() {
 
 #[test]
 fn display() {
+    let error = HttpError {
+        #[cfg(feature = "actix-web")]
+        http_status_code: StatusCode::BAD_REQUEST,
+        public: Box::new(ErrorBody {
+            foo: "foo",
+            bar: 42,
+        }),
+        context: Some("context".to_string()),
+    }
+    .to_string();
+
+    #[cfg(feature = "actix-web")]
     assert_eq!(
-        format!(
-            "{}",
-            HttpError {
-                #[cfg(feature = "actix-web")]
-                http_status_code: StatusCode::BAD_REQUEST,
-                public: Box::new(ErrorBody {
-                    foo: "foo",
-                    bar: 42
-                }),
-                context: Some("context".to_string())
-            }
-        ),
+        error,
         r#"{"context":"context","http_status_code":400,"public":{"bar":42,"foo":"foo"}}"#
             .to_string()
+    );
+
+    #[cfg(not(feature = "actix-web"))]
+    assert_eq!(
+        error,
+        r#"{"context":"context","public":{"bar":42,"foo":"foo"}}"#.to_string()
     );
 }

--- a/explicit-error-http/src/lib.rs
+++ b/explicit-error-http/src/lib.rs
@@ -223,6 +223,7 @@ pub mod prelude {
 }
 
 pub mod derive {
+    #[cfg(feature = "actix-web")]
     pub use explicit_error_derive::HandlerErrorHelpers;
     pub use explicit_error_derive::HttpError;
 }

--- a/explicit-error-http/tests/actix/mod.rs
+++ b/explicit-error-http/tests/actix/mod.rs
@@ -1,0 +1,95 @@
+use actix_web::{App, HttpResponse, body, get, http::StatusCode, test};
+// import only derive to validate that derives work without any required import
+use super::{ErrorBody, MyDomainError};
+use explicit_error_http::derive::HandlerErrorHelpers;
+use serde::Serialize;
+
+#[derive(HandlerErrorHelpers)]
+struct MyHandlerError(explicit_error_http::Error);
+
+impl explicit_error_http::HandlerError for MyHandlerError {
+    fn from_error(value: explicit_error_http::Error) -> Self {
+        MyHandlerError(value)
+    }
+
+    fn public_fault_response(_: &explicit_error_http::Fault) -> impl Serialize {
+        ErrorBody {
+            foo: "fault".to_string(),
+            bar: 500,
+        }
+    }
+
+    fn error(&self) -> &explicit_error_http::Error {
+        &self.0
+    }
+
+    fn domain_response(_: &explicit_error_http::DomainError) -> impl Serialize {
+        ErrorBody {
+            foo: "domain".to_string(),
+            bar: 200,
+        }
+    }
+}
+#[actix_web::test]
+async fn handler_derive() {
+    let app = test::init_service(
+        App::new()
+            .service(domain_error)
+            .service(domain_error2)
+            .service(fault_error),
+    )
+    .await;
+
+    let resp = test::call_service(&app, test::TestRequest::get().uri("/domain").to_request()).await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let resp = serde_json::from_str::<ErrorBody>(
+        std::str::from_utf8(&body::to_bytes(resp.into_body()).await.unwrap_or_default()).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(resp.foo, "domain");
+    assert_eq!(resp.bar, 200);
+
+    let resp =
+        test::call_service(&app, test::TestRequest::get().uri("/domain2").to_request()).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let resp = serde_json::from_str::<ErrorBody>(
+        std::str::from_utf8(&body::to_bytes(resp.into_body()).await.unwrap_or_default()).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(resp.foo, "domain");
+    assert_eq!(resp.bar, 200);
+
+    let resp = test::call_service(&app, test::TestRequest::get().uri("/fault").to_request()).await;
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let resp = serde_json::from_str::<ErrorBody>(
+        std::str::from_utf8(&body::to_bytes(resp.into_body()).await.unwrap_or_default()).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(resp.foo, "fault");
+    assert_eq!(resp.bar, 500);
+}
+
+#[get("/domain")]
+async fn domain_error() -> Result<HttpResponse, MyHandlerError> {
+    Err(explicit_error_http::HttpError {
+        http_status_code: StatusCode::FORBIDDEN,
+        public: Box::new(""),
+        context: None,
+    })?;
+
+    Ok(HttpResponse::Ok().finish())
+}
+
+#[get("/domain2")]
+async fn domain_error2() -> Result<HttpResponse, MyHandlerError> {
+    Err(explicit_error_http::Error::from(MyDomainError))?;
+
+    Ok(HttpResponse::Ok().finish())
+}
+
+#[get("/fault")]
+async fn fault_error() -> Result<HttpResponse, MyHandlerError> {
+    Err(explicit_error_http::Fault::new())?;
+
+    Ok(HttpResponse::Ok().finish())
+}

--- a/explicit-error-http/tests/derive.rs
+++ b/explicit-error-http/tests/derive.rs
@@ -53,8 +53,14 @@ fn http_error() {
             .is_some()
     );
 
+    #[cfg(feature = "actix-web")]
     assert_eq!(
         error.to_string(),
         r#"{"context":"context","http_status_code":400,"public":{"bar":42,"foo":"foo"},"source":"MyDomainError"}"#
+    );
+
+    assert_eq!(
+        error.to_string(),
+        r#"{"context":"context","public":{"bar":42,"foo":"foo"},"source":"MyDomainError"}"#
     );
 }

--- a/explicit-error-http/tests/derive.rs
+++ b/explicit-error-http/tests/derive.rs
@@ -1,0 +1,60 @@
+#[cfg(feature = "actix-web")]
+mod actix;
+
+// import only derive to validate that derives work without any required import
+use explicit_error_http::derive::HttpError;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct ErrorBody {
+    foo: String,
+    bar: i64,
+}
+
+#[derive(Debug, HttpError)]
+struct MyDomainError;
+
+impl From<&MyDomainError> for explicit_error_http::HttpError {
+    fn from(_: &MyDomainError) -> Self {
+        explicit_error_http::HttpError {
+            #[cfg(feature = "actix-web")]
+            http_status_code: actix_web::http::StatusCode::BAD_REQUEST,
+            public: Box::new(ErrorBody {
+                foo: "foo".to_string(),
+                bar: 42,
+            }),
+            context: Some("context".to_string()),
+        }
+    }
+}
+
+#[test]
+fn http_error() {
+    let error = explicit_error_http::ToDomainError::to_domain_error(MyDomainError);
+
+    assert_eq!(
+        error.output,
+        explicit_error_http::HttpError {
+            #[cfg(feature = "actix-web")]
+            http_status_code: actix_web::http::StatusCode::BAD_REQUEST,
+            public: Box::new(ErrorBody {
+                foo: "foo".to_string(),
+                bar: 42,
+            }),
+            context: Some("context".to_string()),
+        }
+    );
+    assert!(
+        error
+            .source
+            .as_ref()
+            .unwrap()
+            .downcast_ref::<MyDomainError>()
+            .is_some()
+    );
+
+    assert_eq!(
+        error.to_string(),
+        r#"{"context":"context","http_status_code":400,"public":{"bar":42,"foo":"foo"},"source":"MyDomainError"}"#
+    );
+}

--- a/explicit-error/Cargo.toml
+++ b/explicit-error/Cargo.toml
@@ -16,7 +16,7 @@ serde = {version = "1.0.219", features = ["derive"]}
 [dev-dependencies]
 actix-web = "4.10.2"
 explicit-error-exit = {path = "../explicit-error-exit"}
-explicit-error-http = {path = "../explicit-error-http"}
+explicit-error-http = {path = "../explicit-error-http", features = ["actix-web"]}
 http = "1.3.1"
 problem_details = "0.8.0"
 sqlx = "0.8.3"

--- a/explicit-error/Cargo.toml
+++ b/explicit-error/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.1.5"
+version = "0.1.6"
 
 [dependencies]
 serde = {version = "1.0.219", features = ["derive"]}

--- a/explicit-error/src/domain.rs
+++ b/explicit-error/src/domain.rs
@@ -6,5 +6,7 @@ where
 {
     fn with_context(self, context: impl std::fmt::Display) -> Self;
 
+    fn context(&self) -> Option<&str>;
+
     fn into_source(self) -> Option<Box<dyn std::error::Error>>;
 }

--- a/explicit-error/src/error.rs
+++ b/explicit-error/src/error.rs
@@ -172,6 +172,23 @@ where
         }
         .downcast_ref::<E>()
     }
+
+    /// Add context of either [Error::Domain] or [Error::Fault] variant.
+    /// Override existing context
+    pub fn with_context(self, context: impl Display) -> Self {
+        match self {
+            Error::Domain(d) => Error::Domain(Box::new(d.with_context(context))),
+            Error::Fault(fault) => Error::Fault(fault.with_context(context)),
+        }
+    }
+
+    /// Return the context of either [Error::Domain] or [Error::Fault] variant.
+    pub fn context(&self) -> Option<&str> {
+        match self {
+            Error::Domain(d) => d.context(),
+            Error::Fault(fault) => fault.context(),
+        }
+    }
 }
 
 pub fn errors_chain_debug(source: &dyn StdError) -> String {

--- a/explicit-error/src/error.rs
+++ b/explicit-error/src/error.rs
@@ -20,8 +20,10 @@ where
 {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match self {
-            Error::Domain(explicit_error) => Some(explicit_error.as_ref()),
-            Error::Fault(fault) => fault.source.as_ref().map(|e| e.as_ref()),
+            Error::Domain(explicit_error) => {
+                explicit_error.source().or(Some(explicit_error.as_ref()))
+            }
+            Error::Fault(fault) => fault.source().or(Some(fault)),
         }
     }
 }
@@ -475,3 +477,6 @@ impl<T> ResultFaultWithContext<T> for Result<T, Fault> {
         }
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/explicit-error/src/error/test.rs
+++ b/explicit-error/src/error/test.rs
@@ -1,5 +1,7 @@
-use explicit_error_exit::*;
-use std::{error::Error as StdError, process::ExitCode};
+use explicit_error_exit::{prelude::*, *};
+use std::{backtrace::BacktraceStatus, error::Error as StdError, process::ExitCode};
+
+use super::OptionFault;
 
 #[derive(Debug, PartialEq)]
 struct MyError(bool);
@@ -126,4 +128,304 @@ fn downcast_source() {
             .downcast_source::<MyError>()
             .is_err()
     );
+}
+
+#[test]
+fn with_context() {
+    assert_eq!(
+        Error::Fault(Fault::new())
+            .with_context("context")
+            .context()
+            .unwrap(),
+        "context"
+    );
+
+    assert_eq!(
+        Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS),
+            source: None
+        }))
+        .with_context("context")
+        .context()
+        .unwrap(),
+        "context"
+    );
+}
+
+#[test]
+fn context() {
+    assert_eq!(
+        Error::Fault(Fault::new().with_context("context"))
+            .context()
+            .unwrap(),
+        "context"
+    );
+
+    assert_eq!(
+        Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS).with_context("context"),
+            source: None
+        }))
+        .context()
+        .unwrap(),
+        "context"
+    );
+}
+
+#[test]
+fn errors_chain_debug() {
+    #[derive(Debug)]
+    struct Chain1(MyError);
+
+    impl std::fmt::Display for Chain1 {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Chain1",)
+        }
+    }
+
+    impl std::error::Error for Chain1 {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    #[derive(Debug)]
+    struct Chain0(Chain1);
+
+    impl std::fmt::Display for Chain0 {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "Chain1",)
+        }
+    }
+
+    impl std::error::Error for Chain0 {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    assert_eq!(
+        crate::errors_chain_debug(&Chain0(Chain1(MyError::default()))),
+        "Chain0(Chain1(MyError(true)))->Chain1(MyError(true))->MyError(true)"
+    );
+}
+
+#[test]
+fn map_err_or_fault() {
+    let closure = |e: MyError| match e.0 {
+        true => Ok(ExitError::new("", ExitCode::SUCCESS)),
+        false => Err(e),
+    };
+
+    assert_eq!(Ok(()).map_err_or_fault(closure).unwrap(), ());
+
+    assert!(
+        Err::<(), _>(MyError::default())
+            .map_err_or_fault(closure)
+            .unwrap_err()
+            .is_domain()
+    );
+
+    assert!(
+        Err::<(), _>(MyError(false))
+            .map_err_or_fault(closure)
+            .unwrap_err()
+            .is_fault()
+    );
+}
+
+#[test]
+fn or_fault_no_source() {
+    assert_eq!(
+        Err::<(), _>(())
+            .or_fault_no_source()
+            .unwrap_err()
+            .backtrace_status(),
+        BacktraceStatus::Disabled
+    );
+    assert!(Ok::<_, ()>(()).or_fault_no_source().is_ok());
+}
+
+#[test]
+fn or_fault() {
+    let fault = Err::<(), _>(MyError::default()).or_fault().unwrap_err();
+    assert_eq!(fault.backtrace_status(), BacktraceStatus::Disabled);
+    assert_eq!(
+        *fault.source.unwrap().downcast::<MyError>().unwrap(),
+        MyError::default()
+    );
+
+    assert!(Ok::<_, MyError>(()).or_fault().is_ok());
+}
+
+#[test]
+fn or_fault_no_source_force() {
+    assert_eq!(
+        Err::<(), _>(())
+            .or_fault_no_source_force()
+            .unwrap_err()
+            .backtrace_status(),
+        BacktraceStatus::Captured
+    );
+    assert!(Ok::<_, ()>(()).or_fault_no_source_force().is_ok());
+}
+
+#[test]
+fn or_fault_force() {
+    let fault = Err::<(), _>(MyError::default())
+        .or_fault_force()
+        .unwrap_err();
+    assert_eq!(fault.backtrace_status(), BacktraceStatus::Captured);
+    assert_eq!(
+        *fault.source.unwrap().downcast::<MyError>().unwrap(),
+        MyError::default()
+    );
+
+    assert!(Ok::<_, MyError>(()).or_fault_force().is_ok());
+}
+
+#[test]
+fn try_map_on_source() {
+    assert!(
+        Err::<(), _>(Error::Fault(Fault::new()))
+            .try_map_on_source(|_: MyError| ExitError::new("", ExitCode::SUCCESS))
+            .unwrap_err()
+            .is_fault()
+    );
+
+    assert!(
+        Err::<(), _>(Error::Fault(Fault::new().with_source(MyError::default())))
+            .try_map_on_source(|_: sqlx::Error| ExitError::new("", ExitCode::SUCCESS))
+            .unwrap_err()
+            .is_fault()
+    );
+
+    assert!(
+        Err::<(), _>(Error::Fault(Fault::new().with_source(MyError::default())))
+            .try_map_on_source(|_: MyError| ExitError::new("", ExitCode::SUCCESS))
+            .unwrap_err()
+            .is_domain()
+    );
+
+    assert!(
+        Err::<(), _>(Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS),
+            source: None
+        })))
+        .try_map_on_source(|_: MyError| Fault::new())
+        .unwrap_err()
+        .is_domain()
+    );
+
+    assert!(
+        Err::<(), _>(Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS),
+            source: Some(Box::new(MyError::default()))
+        })))
+        .try_map_on_source(|_: sqlx::Error| Fault::new())
+        .unwrap_err()
+        .is_domain()
+    );
+
+    assert!(
+        Err::<(), _>(Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS),
+            source: Some(Box::new(MyError::default()))
+        })))
+        .try_map_on_source(|_: MyError| Fault::new())
+        .unwrap_err()
+        .is_fault()
+    );
+}
+
+#[test]
+fn result_with_context() {
+    assert_eq!(
+        Err::<(), _>(Error::Fault(Fault::new()))
+            .with_context("context")
+            .unwrap_err()
+            .context()
+            .unwrap(),
+        "context"
+    );
+
+    assert_eq!(
+        Err::<(), _>(Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS),
+            source: None
+        })))
+        .with_context("context")
+        .unwrap_err()
+        .context()
+        .unwrap(),
+        "context"
+    );
+
+    assert!(Ok::<(), Fault>(()).with_context("context").is_ok());
+}
+
+#[test]
+fn unwrap_err_source() {
+    assert_eq!(
+        Err::<(), _>(Error::Fault(Fault::new().with_source(MyError::default())))
+            .unwrap_err()
+            .downcast_source::<MyError>()
+            .unwrap(),
+        MyError::default()
+    );
+}
+
+#[should_panic]
+#[test]
+fn unwrap_err_source_panic() {
+    Err::<(), _>(Error::Fault(Fault::new()))
+        .unwrap_err()
+        .downcast_source::<MyError>()
+        .unwrap();
+}
+
+#[should_panic]
+#[test]
+fn unwrap_err_source_panic2() {
+    Err::<(), _>(Error::Fault(
+        Fault::new().with_source(sqlx::Error::RowNotFound),
+    ))
+    .unwrap_err()
+    .downcast_source::<MyError>()
+    .unwrap();
+}
+
+#[test]
+fn ok_or_fault() {
+    assert_eq!(
+        None::<()>.ok_or_fault().unwrap_err().backtrace_status(),
+        BacktraceStatus::Disabled
+    );
+    assert_eq!(Some(()).ok_or_fault().unwrap(), ());
+}
+
+#[test]
+fn ok_or_fault_force() {
+    assert_eq!(
+        None::<()>
+            .ok_or_fault_force()
+            .unwrap_err()
+            .backtrace_status(),
+        BacktraceStatus::Captured
+    );
+    assert_eq!(Some(()).ok_or_fault().unwrap(), ());
+}
+
+#[test]
+fn result_fault_with_context() {
+    assert_eq!(
+        Err::<(), _>(Fault::new())
+            .with_context("context")
+            .unwrap_err()
+            .context()
+            .unwrap(),
+        "context"
+    );
+
+    assert!(Ok::<(), Fault>(()).with_context("context").is_ok());
 }

--- a/explicit-error/src/error/test.rs
+++ b/explicit-error/src/error/test.rs
@@ -57,3 +57,73 @@ fn source() {
         &MyError::default()
     );
 }
+
+#[test]
+fn is_domain() {
+    assert!(!Error::Fault(Fault::new()).is_domain());
+    assert!(Error::from(ExitError::new("", ExitCode::SUCCESS)).is_domain());
+}
+
+#[test]
+fn is_fault() {
+    assert!(Error::Fault(Fault::new()).is_fault());
+    assert!(!Error::from(ExitError::new("", ExitCode::SUCCESS)).is_fault());
+}
+
+#[should_panic]
+#[test]
+fn unwrap_panic() {
+    Error::Fault(Fault::new()).unwrap();
+}
+
+#[test]
+fn unwrap() {
+    Error::from(ExitError::new("", ExitCode::SUCCESS)).unwrap();
+}
+
+#[should_panic]
+#[test]
+fn unwrap_fault_panic() {
+    Error::from(ExitError::new("", ExitCode::SUCCESS)).unwrap_fault();
+}
+
+#[test]
+fn unwrap_fault() {
+    Error::Fault(Fault::new()).unwrap_fault();
+}
+
+#[test]
+fn downcast_source() {
+    assert!(
+        Error::Fault(Fault::new())
+            .downcast_source::<Fault>()
+            .is_ok()
+    );
+    assert!(
+        Error::Fault(Fault::new().with_source(MyError::default()))
+            .downcast_source::<MyError>()
+            .is_ok()
+    );
+    assert!(
+        Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS),
+            source: None
+        }))
+        .downcast_source::<DomainError>()
+        .is_ok()
+    );
+    assert!(
+        Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS),
+            source: Some(Box::new(MyError::default()))
+        }))
+        .downcast_source::<MyError>()
+        .is_ok()
+    );
+
+    assert!(
+        Error::Fault(Fault::new())
+            .downcast_source::<MyError>()
+            .is_err()
+    );
+}

--- a/explicit-error/src/error/test.rs
+++ b/explicit-error/src/error/test.rs
@@ -1,0 +1,59 @@
+use explicit_error_exit::*;
+use std::{error::Error as StdError, process::ExitCode};
+
+#[derive(Debug, PartialEq)]
+struct MyError(bool);
+
+impl Default for MyError {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+impl std::fmt::Display for MyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl StdError for MyError {}
+
+#[test]
+fn source() {
+    assert!(
+        Error::Fault(Fault::new())
+            .source()
+            .unwrap()
+            .downcast_ref::<Fault>()
+            .is_some()
+    );
+    assert_eq!(
+        Error::Fault(Fault::new().with_source(MyError::default()))
+            .source()
+            .unwrap()
+            .downcast_ref::<MyError>()
+            .unwrap(),
+        &MyError::default()
+    );
+    assert!(
+        Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS),
+            source: None
+        }))
+        .source()
+        .unwrap()
+        .downcast_ref::<DomainError>()
+        .is_some()
+    );
+    assert_eq!(
+        Error::Domain(Box::new(DomainError {
+            output: ExitError::new("", ExitCode::SUCCESS),
+            source: Some(Box::new(MyError::default()))
+        }))
+        .source()
+        .unwrap()
+        .downcast_ref::<MyError>()
+        .unwrap(),
+        &MyError::default()
+    );
+}

--- a/explicit-error/src/fault.rs
+++ b/explicit-error/src/fault.rs
@@ -1,6 +1,9 @@
 use crate::{domain::Domain, error::Error};
 use serde::{Serialize, Serializer};
-use std::{backtrace::Backtrace, error::Error as StdError};
+use std::{
+    backtrace::{Backtrace, BacktraceStatus},
+    error::Error as StdError,
+};
 
 /// Wrapper for errors that should not happen but cannot panic.
 /// It is wrapped in the [Error::Fault] variant.
@@ -166,6 +169,16 @@ impl Fault {
             context: None,
         }
     }
+
+    /// Return the status of the backtrace
+    pub fn backtrace_status(&self) -> BacktraceStatus {
+        self.backtrace.status()
+    }
+
+    /// Return the context
+    pub fn context(&self) -> Option<&str> {
+        self.context.as_deref()
+    }
 }
 
 impl Default for Fault {
@@ -192,3 +205,6 @@ where
 {
     s.serialize_str(&backtrace.to_string())
 }
+
+#[cfg(test)]
+mod test;

--- a/explicit-error/src/fault/test.rs
+++ b/explicit-error/src/fault/test.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+#[test]
+fn from_for_error() {
+    assert!(explicit_error_exit::Error::from(explicit_error_exit::Fault::new()).is_fault());
+}
+
+#[test]
+fn source() {
+    assert!(
+        Fault::new()
+            .with_source(sqlx::Error::RowNotFound)
+            .source()
+            .unwrap()
+            .downcast_ref::<sqlx::Error>()
+            .is_some()
+    );
+
+    assert!(Fault::new().source().is_none());
+}
+
+#[test]
+fn new() {
+    let fault = Fault::new();
+    assert!(fault.context().is_none());
+    assert!(fault.source.is_none());
+    assert_eq!(fault.backtrace.status(), BacktraceStatus::Disabled);
+}
+
+#[test]
+fn with_source() {
+    assert!(
+        Fault::new()
+            .with_source(sqlx::Error::RowNotFound)
+            .source
+            .unwrap()
+            .downcast::<sqlx::Error>()
+            .is_ok()
+    );
+}
+
+#[test]
+fn with_context() {
+    let fault = Fault::new().with_context("context");
+    assert_eq!(fault.context.as_ref().unwrap(), "context");
+    assert_eq!(
+        fault.with_context("context 2").context.unwrap(),
+        "context 2"
+    );
+}
+
+#[test]
+fn new_force() {
+    let fault = Fault::new_force();
+    assert!(fault.context().is_none());
+    assert!(fault.source.is_none());
+    assert_eq!(fault.backtrace.status(), BacktraceStatus::Captured);
+}
+
+#[test]
+fn backtrace_status() {
+    assert_eq!(Fault::new().backtrace_status(), BacktraceStatus::Disabled);
+    assert_eq!(
+        Fault::new_force().backtrace.status(),
+        BacktraceStatus::Captured
+    );
+}
+
+#[test]
+fn context() {
+    assert_eq!(
+        Fault::new().with_context("context").context().unwrap(),
+        "context"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,7 @@
+test:
+    cargo test -p explicit-error 
+    cargo test -p explicit-error-exit 
+    cargo test -p explicit-error-http --lib
+    cargo test -p explicit-error-http --lib --features actix-web
+    cargo test -p explicit-error-http --doc --features actix-web
+    cargo build --example actix


### PR DESCRIPTION
In addition to test, add some helpers and breaking change on unwrap_err_source. `unwrap_err_source` is replaced by `downcast_source` on `Error` instead of `Result<T, Error>`. New naming is more explicit and more straightforward to use.