### PR TITLE
Remove error domain bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix-web",
  "explicit-error-exit",

--- a/explicit-error/Cargo.toml
+++ b/explicit-error/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 serde = {version = "1.0.219", features = ["derive"]}

--- a/explicit-error/src/error.rs
+++ b/explicit-error/src/error.rs
@@ -9,7 +9,7 @@ use std::{error::Error as StdError, fmt::Display};
 /// The [Error::Domain] variant is for domain errors that provide feedbacks to the user.
 /// For library or functions that require the caller to pattern match on the returned error, a dedicated type is prefered.
 #[derive(Debug)]
-pub enum Error<D: Domain> {
+pub enum Error<D> {
     Domain(Box<D>), // Box for size: https://doc.rust-lang.org/clippy/lint_configuration.html#large-error-threshold
     Fault(Fault),
 }


### PR DESCRIPTION
The bound is not necessary, having no bound can be useful for libraries to easily handle faults.