### PR TITLE
Add MainError and MainResult to explicit-error-exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "explicit-error-exit"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "explicit-error",
  "explicit-error-derive",

--- a/explicit-error-exit/Cargo.toml
+++ b/explicit-error-exit/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["error", "error-handling"]
 license = "Apache-2.0"
 name = "explicit-error-exit"
 repository = "https://github.com/Tipnos/explicit-error"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 explicit-error = {version = "0", path = "../explicit-error"}

--- a/explicit-error-exit/src/error.rs
+++ b/explicit-error-exit/src/error.rs
@@ -94,6 +94,8 @@ impl ExitError {
     }
 }
 
+impl std::error::Error for ExitError {}
+
 impl Display for ExitError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.message)

--- a/explicit-error-exit/src/lib.rs
+++ b/explicit-error-exit/src/lib.rs
@@ -2,7 +2,7 @@
 //! Based on the [explicit-error](explicit_error) crate, its chore tenet is to favor explicitness by inlining the error output while remaining concise.
 //!
 //! The key features are:
-//! - Provide [MainResult] as a returned type of crate's main function with properly formated console error.
+//! - Provide [MainResult] as a returned type of crate's main function to have well formated error.
 //! - Explicitly mark any error wrapped in a [Result] as a [Fault], a backtrace is captured.
 //! - Inline transformation of any errors wrapped in a [Result] into an [Error].
 //! - A derive macro [ExitError](derive::ExitError) to easily declare how enum or struct errors transform into an [Error].
@@ -15,13 +15,14 @@
 //! ## Inline
 //!
 //! In the body of the function you can explicitly turn errors as exit errors using [ExitError] or marking them as [Fault].
-//! ```rust
+//! ```no_run
 //! use explicit_error_exit::{prelude::*, ExitError, Result, Fault, MainResult};
 //! use std::process::ExitCode;
 //! // Import the prelude to enable functions on std::result::Result
 //!
 //! fn main() -> MainResult { // Error message returned: "Error: Something went wrong because .."
 //!     business_logic()?;
+//!     Ok(())
 //! }
 //!
 //! fn business_logic() -> Result<()> {


### PR DESCRIPTION
Add `MainError` that implements `Termination` to have well formated errors when exiting main